### PR TITLE
Refactor to make errors work better

### DIFF
--- a/common/common.proto
+++ b/common/common.proto
@@ -24,12 +24,10 @@ message ReceivedResponse {
 }
 
 message ErrorResponse {
-    /* The trace id of the operation that has errored */
-    string trace_id = 1;
     /* The type of error that has occurred */
-    ErrorCode error_code = 2;
+    ErrorCode error_code = 1;
     /* Description of error */
-    string msg = 3;
+    string msg = 2;
 }
 
 enum ErrorCode {

--- a/streams/bridge/definition.proto
+++ b/streams/bridge/definition.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "common/common.proto";
+
 option java_multiple_files = true;
 option java_package = "games.mythical.saga.sdk.proto.streams.bridge";
 
@@ -7,13 +9,19 @@ package saga.rpc.streams.bridge;
 
 /* Results from a Bridge status update gRPC stream call */
 message BridgeStatusUpdate {
-    string trace_id = 1;
-    string oauth_id = 2;
-    string game_item_type_id = 3;
-    string game_inventory_id = 4;
-    string destination_address = 5;
-    string destination_chain = 6;
-    string origin_address = 7;
-    string mythical_transaction_id = 8;
-    string mainnet_transaction_id = 9;
+    string oauth_id = 1;
+    string game_item_type_id = 2;
+    string game_inventory_id = 3;
+    string destination_address = 4;
+    string destination_chain = 5;
+    string origin_address = 6;
+    string mythical_transaction_id = 7;
+    string mainnet_transaction_id = 8;
+}
+
+message BridgeUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        BridgeStatusUpdate status_update = 2;
+    }
 }

--- a/streams/gamecoin/definition.proto
+++ b/streams/gamecoin/definition.proto
@@ -1,22 +1,29 @@
 syntax = "proto3";
 
+import "common/common.proto";
+import "common/gamecoin/definition.proto";
+
 option java_multiple_files = true;
 option java_package = "games.mythical.saga.sdk.proto.streams.gamecoin";
-
-import "common/gamecoin/definition.proto";
 
 package saga.rpc.streams.gamecoin;
 
 /* Results from a GameCoin status update gRPC stream call */
 message GameCoinStatusUpdate {
-    string trace_id = 1;
     /* User of GameCoin */
-    string oauth_id = 2;
-    string currency_id = 3;
+    string oauth_id = 1;
+    string currency_id = 2;
     /* Amount of coins */
-    int32 coin_count = 4;
+    int32 coin_count = 3;
     /* State of the GameCoin, see GameCoinState */
     saga.proto.common.gamecoin.GameCoinState game_coin_state = 8;
+}
+
+message GameCoinUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        GameCoinStatusUpdate status_update = 2;
+    }
 }
 
 /* GameCoin information sent on a confirm request */

--- a/streams/item/definition.proto
+++ b/streams/item/definition.proto
@@ -1,24 +1,31 @@
 syntax = "proto3";
 
+import "common/common.proto";
+import "common/item/definition.proto";
+
 option java_multiple_files = true;
 option java_package = "games.mythical.saga.sdk.proto.streams.item";
-
-import "common/item/definition.proto";
 
 package saga.rpc.streams.item;
 
 /* Results from an Item status update gRPC stream call */
 message ItemStatusUpdate {
-    string trace_id = 1;
     /* Game's unique Id for the Item */
-    string game_inventory_id = 2;
+    string game_inventory_id = 1;
     /* Game's ItemTypeId for the ItemType for this Item */
-    string game_item_type_id = 3;
+    string game_item_type_id = 2;
     /* User for this Item */
-    string oauth_id = 4;
-    int32 serial_number = 5;
+    string oauth_id = 3;
+    int32 serial_number = 4;
     /* Metadata address */
-    string metadata_uri = 6;
+    string metadata_uri = 5;
     /* State of the Item, see ItemState */
     saga.proto.common.item.ItemState item_state = 8;
+}
+
+message ItemUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        ItemStatusUpdate status_update = 2;
+    }
 }

--- a/streams/itemtype/definition.proto
+++ b/streams/itemtype/definition.proto
@@ -1,17 +1,24 @@
 syntax = "proto3";
 
+import "common/common.proto";
+import "common/itemtype/definition.proto";
+
 option java_multiple_files = true;
 option java_package = "games.mythical.saga.sdk.proto.streams.itemtype";
-
-import "common/itemtype/definition.proto";
 
 package saga.rpc.streams.itemtype;
 
 /* Results from a ItemType status update gRPC stream call */
 message ItemTypeStatusUpdate {
-    string trace_id = 1;
     /* Game's unique id for this ItemType */
-    string game_item_type_id = 2;
+    string game_item_type_id = 1;
     /* State of the ItemType, see ItemTypeState */
     saga.proto.common.itemtype.ItemTypeState item_type_state = 8;
+}
+
+message ItemTypeUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        ItemTypeStatusUpdate status_update = 2;
+    }
 }

--- a/streams/listing/definition.proto
+++ b/streams/listing/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/listing/definition.proto";
 
 option java_multiple_files = true;
@@ -9,15 +10,21 @@ package saga.rpc.streams.listing;
 
 /* Results from a Listing status update gRPC stream call */
 message ListingStatusUpdate {
-    string trace_id = 1;
     /* User of this Listing */
-    string oauth_id = 2;
+    string oauth_id = 1;
     /* Quote id associated to this Listing */
-    string quote_id = 3;
+    string quote_id = 2;
     /* Unique id for this listing */
-    string listing_id = 4;
+    string listing_id = 3;
     /* total cose on listing */
-    string total = 5;
+    string total = 4;
     /* State of the Listing, see ListingState */
     saga.proto.common.listing.ListingState listing_state = 7;
+}
+
+message ListingUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        ListingStatusUpdate status_update = 2;
+    }
 }

--- a/streams/myth/definition.proto
+++ b/streams/myth/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/myth/definition.proto";
 
 option java_multiple_files = true;
@@ -9,7 +10,13 @@ package saga.rpc.streams.myth;
 
 /* Results from a MYTH Token status update gRPC stream call */
 message MythTokenStatusUpdate {
-    string trace_id = 1;
     /* State of the MYTH Token, see MythTokenState */
-    saga.proto.common.myth.MythTokenState token_state = 2;
+    saga.proto.common.myth.MythTokenState token_state = 1;
+}
+
+message MythTokenUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        MythTokenStatusUpdate status_update = 2;
+    }
 }

--- a/streams/offer/definition.proto
+++ b/streams/offer/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/offer/definition.proto";
 
 option java_multiple_files = true;
@@ -9,17 +10,23 @@ package saga.rpc.streams.offer;
 
 /* Results from a Offer status update gRPC stream call */
 message OfferStatusUpdate {
-    string trace_id = 1;
     /* User of this Offer */
-    string oauth_id = 2;
+    string oauth_id = 1;
     /* Quote associated to this Offer */
-    string quote_id = 3;
+    string quote_id = 2;
     /* Unique id for this Offer */
-    string offer_id = 4;
+    string offer_id = 3;
     /* Game's id for the Item associated with this Offer */
-    string game_inventory_id = 5;
+    string game_inventory_id = 4;
     /* Total price for the offer */
-    string total = 6;
+    string total = 5;
     /* State of the Offer, see OfferState */
-    saga.proto.common.offer.OfferState offer_state = 7;
+    saga.proto.common.offer.OfferState offer_state = 6;
+}
+
+message OfferUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        OfferStatusUpdate status_update = 2;
+    }
 }

--- a/streams/order/definition.proto
+++ b/streams/order/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/order/definition.proto";
 
 option java_multiple_files = true;
@@ -9,13 +10,19 @@ package saga.rpc.streams.order;
 
 /* Results from an Order status update gRPC stream call */
 message OrderStatusUpdate {
-    string trace_id = 1;
     /* User of the Order */
-    string oauth_id = 2;
-    string quote_id = 3; // @exclude TODO: quote == order?
-    string order_id = 4;
+    string oauth_id = 1;
+    string quote_id = 2; // @exclude TODO: quote == order?
+    string order_id = 3;
     /* Total price of the Order */
-    string total = 5;
+    string total = 4;
     /* State of the Order, see OrderState */
-    saga.proto.common.order.OrderState order_state = 6;
+    saga.proto.common.order.OrderState order_state = 5;
+}
+
+message OrderUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        OrderStatusUpdate status_update = 2;
+    }
 }

--- a/streams/payment/definition.proto
+++ b/streams/payment/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/payment/definition.proto";
 
 option java_multiple_files = true;
@@ -8,9 +9,15 @@ option java_package = "games.mythical.saga.sdk.proto.streams.payment";
 package saga.rpc.streams.payment;
 
 /* Result of payment method creation, update, or deletion */
-message PaymentMethodUpdate {
-  string trace_id = 1;
-  string oauth_id = 2;
-  bool default = 3;
-  saga.proto.common.payment.PaymentMethodUpdateStatus payment_method_status = 4;
+message PaymentMethodStatusUpdate {
+  string oauth_id = 1;
+  bool default = 2;
+  saga.proto.common.payment.PaymentMethodUpdateStatus payment_method_status = 3;
+}
+
+message PaymentUpdate {
+  oneof update {
+      saga.common.ErrorResponse error = 1;
+      PaymentMethodStatusUpdate status_update = 2;
+  }
 }

--- a/streams/stream.proto
+++ b/streams/stream.proto
@@ -10,6 +10,7 @@ import "streams/listing/definition.proto";
 import "streams/myth/definition.proto";
 import "streams/offer/definition.proto";
 import "streams/order/definition.proto";
+import "streams/payment/definition.proto";
 import "streams/user/definition.proto";
 
 option java_multiple_files = true;
@@ -21,15 +22,16 @@ package saga.rpc.streams;
 message StatusUpdate {
     string trace_id = 1;
     oneof status_update {
-        streams.bridge.BridgeStatusUpdate bridge_status = 2;
-        streams.gamecoin.GameCoinStatusUpdate game_coin_status = 3;
-        streams.item.ItemStatusUpdate item_status = 4;
-        streams.itemtype.ItemTypeStatusUpdate item_type_status = 5;
-        streams.listing.ListingStatusUpdate listing_status = 6;
-        streams.myth.MythTokenStatusUpdate myth_token_status = 7;
-        streams.offer.OfferStatusUpdate offer_status = 8;
-        streams.order.OrderStatusUpdate order_status = 9;
-        streams.user.UserStatusUpdate user_status = 10;
+        streams.bridge.BridgeUpdate bridge_update = 2;
+        streams.gamecoin.GameCoinUpdate game_coin_update = 3;
+        streams.item.ItemUpdate item_update = 4;
+        streams.itemtype.ItemTypeUpdate item_type_update = 5;
+        streams.listing.ListingUpdate listing_update = 6;
+        streams.myth.MythTokenUpdate myth_token_update = 7;
+        streams.offer.OfferUpdate offer_update = 8;
+        streams.order.OrderUpdate order_update = 9;
+        streams.payment.PaymentUpdate payment_update = 10;
+        streams.user.UserUpdate user_update = 11;
     }
     int64 created_timestamp = 15;
 }

--- a/streams/user/definition.proto
+++ b/streams/user/definition.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common/common.proto";
 import "common/user/definition.proto";
 
 option java_multiple_files = true;
@@ -9,9 +10,15 @@ package saga.rpc.streams.user;
 
 /* Results from a User status update gRPC stream call */
 message UserStatusUpdate {
-    string trace_id = 1;
     /* Unique id for the user */
-    string oauth_id = 2;
+    string oauth_id = 1;
     /* State of the User, see UserState */
-    saga.proto.common.user.UserState user_state = 3;
+    saga.proto.common.user.UserState user_state = 2;
+}
+
+message UserUpdate {
+    oneof update {
+        saga.common.ErrorResponse error = 1;
+        UserStatusUpdate status_update = 2;
+    }
 }


### PR DESCRIPTION
Started to update the SDK and realized there was no way to get the error to the correct executor. Wrapped the status updates in a general update with a oneof that includes an error response. Also realized that the trace id is in the wrapper for update messages so are not needed in the update message itself.