### PR TITLE
MYTHOS-558 - Changed response proto for payments

### DIFF
--- a/api/itemtype/definition.proto
+++ b/api/itemtype/definition.proto
@@ -22,7 +22,7 @@ message ItemTypeProto {
     string title_id = 5;
     PriRevShareSettings pri_rev_share_settings = 6;
     SecRevShareSettings sec_rev_share_settings = 7;
-    /* Is this iten withdrawable? */
+    /* Is this item withdrawable? */
     bool withdrawable = 8;
     PriceMap price_map = 9;
     saga.proto.common.itemtype.ItemTypeState item_type_state = 10;

--- a/api/payment/definition.proto
+++ b/api/payment/definition.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/struct.proto";
 import "common/payment/definition.proto";
 
 option java_multiple_files = true;

--- a/api/payment/definition.proto
+++ b/api/payment/definition.proto
@@ -59,7 +59,7 @@ message UpholdPaymentData {
     string temp_state_code = 1;
     string email = 2;
     string status = 3;
-    google.protobuf.Struct verifications = 4;
+    string verifications = 4;
     string birth_date = 5;
     repeated UpholdCardProto cards = 6;
 }

--- a/streams/payment/definition.proto
+++ b/streams/payment/definition.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "common/common.proto";
 import "common/payment/definition.proto";
+import "api/payment/definition.proto";
 
 option java_multiple_files = true;
 option java_package = "games.mythical.saga.sdk.proto.streams.payment";
@@ -10,9 +11,8 @@ package saga.rpc.streams.payment;
 
 /* Result of payment method creation, update, or deletion */
 message PaymentMethodStatusUpdate {
-  string oauth_id = 1;
-  bool default = 2;
-  saga.proto.common.payment.PaymentMethodUpdateStatus payment_method_status = 3;
+  saga.api.payment.PaymentMethodProto payment_method = 1;
+  saga.proto.common.payment.PaymentMethodUpdateStatus payment_method_status = 2;
 }
 
 message PaymentUpdate {


### PR DESCRIPTION
Lemme know if this makes sense, its a much different proto field organization from old IVI SDK with the individual fields, here we're using the same proto object from the GET call.

What this means from the executor end on the SDK is instead of messing with individual fields, it's always going to be the java object equal.